### PR TITLE
Add colors to the outputs depending on the number of stars

### DIFF
--- a/lib/npm-check-github-stars.js
+++ b/lib/npm-check-github-stars.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('colors');
 const fs = require('fs');
 const path = require('path');
 const npmToGitHub = require('npm-to-github');

--- a/lib/output.js
+++ b/lib/output.js
@@ -8,7 +8,13 @@ function print(dependencies, values) {
         const dependencie = dependencies[index];
         const stars = values[index].toLocaleString();
         const line = pad(dependencie, padding) + stars;
-        console.log(line);
+        if (stars < 50) {
+            console.log(line.red);
+        } else if (stars < 200) {
+            console.log(line.yellow);
+        } else {
+            console.log(line.green);
+        }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "npm run lint"
   },
   "dependencies": {
+    "colors": "1.2.0",
     "npm-to-github": "1.0.1",
     "update-notifier": "2.1.0"
   },


### PR DESCRIPTION
Hello Olivier,

I hope this finds you well. I recently used your npm package and i wanted to congratulate you for this project. 
I added a simple feature in this commit, which is adding colors to the displayed messages depending on the number of stars of each npm package (red for less than 50 stars, yellow for less than 200 and green for above). 
For this purpose, I used the package colors which is very known and very stable. 
If you have any remarks or suggestions, please tell me.

Best regards,
Othmane